### PR TITLE
Enlarge svg icons in "what I'm doing" section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -612,8 +612,8 @@ main {
 .service-icon-box img { 
   margin: auto;
   filter: brightness(0) saturate(100%) invert(27%) sepia(51%) saturate(2878%) hue-rotate(346deg) brightness(104%) contrast(97%);
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   object-fit: contain;
 }
 

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
 
               <div class="service-icon-box">
                 <img src="./assets/images/icon-design.svg
-                " alt="design icon" width="40">
+                " alt="design icon" width="48">
               </div>
 
               <div class="service-content-box">
@@ -264,7 +264,7 @@
             <li class="service-item">
 
               <div class="service-icon-box">
-                <img src="./assets/images/icon-app.svg" alt="mobile app icon" width="40">
+                <img src="./assets/images/icon-app.svg" alt="mobile app icon" width="48">
               </div>
 
               <div class="service-content-box">
@@ -278,7 +278,7 @@
             <li class="service-item">
 
               <div class="service-icon-box">
-                <img src="./assets/images/icon-app.svg" alt="mobile app icon" width="40">
+                <img src="./assets/images/icon-app.svg" alt="mobile app icon" width="48">
               </div>
 
               <div class="service-content-box">
@@ -294,7 +294,7 @@
             <li class="service-item">
 
               <div class="service-icon-box">
-                <img src="./assets/images/icon-dev.svg" alt="mobile app icon" width="40">
+                <img src="./assets/images/icon-dev.svg" alt="mobile app icon" width="48">
               </div>
 
               <div class="service-content-box">


### PR DESCRIPTION
Increase the size of SVG icons in the "What I'm doing" section from `width="40"` to `width="48"`.

The icons were too small, and this change makes them subtly larger for improved visibility without being overly prominent.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb9c6cdb-3a28-428f-9b72-0841e662f701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb9c6cdb-3a28-428f-9b72-0841e662f701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

